### PR TITLE
Add support for ndjson and blob

### DIFF
--- a/test/tests/files_tests.cljs
+++ b/test/tests/files_tests.cljs
@@ -47,11 +47,39 @@
                     (fn [err files]
                       (let [hash (:Hash files)]
                         (files/fget hash
-                                    {:req-opts {:compress true}}
+                                    {}
                                     (fn [err content]
                                       (is (= err nil))
                                       (is (> (count content) 0))
                                       (is (= (parse-ipfs-content content) {:this-is "EDN FILE"}))
+                                      (done))))))))
+
+(deftest fget-args-test []
+  (async done
+         (core/init-ipfs)
+         (files/add (to-buffer "{:this-is \"EDN FILE\"}")
+                    (fn [err files]
+                      (let [hash (:Hash files)]
+                        (files/fget hash
+                                    {:compress true}
+                                    (fn [err content]
+                                      (is (= err nil))
+                                      (is (> (count content) 0))
+                                      (is (< (count content) 1000))
+                                      (done))))))))
+
+(deftest fget-binary-test []
+  (async done
+         (core/init-ipfs)
+         (files/add (to-buffer "{:this-is \"EDN FILE\"}")
+                    (fn [err files]
+                      (let [hash (:Hash files)]
+                        (files/fget hash
+                                    {:binary? true}
+                                    (fn [err content]
+                                      (is (= err nil))
+                                      (is (= (type content) (type (js/ArrayBuffer.))))
+                                      (is (= (parse-ipfs-content (.decode (js/TextDecoder. "utf-8") content)) {:this-is "EDN FILE"}))
                                       (done))))))))
 
 (deftest cat-test []

--- a/test/tests/files_tests.cljs
+++ b/test/tests/files_tests.cljs
@@ -43,20 +43,26 @@
 (deftest fget-test []
   (async done
          (core/init-ipfs)
-         (files/fget "QmU5RLaShDjmXD2qb123Soj3nHKgQn76d8jab8mNp55X1V"
-                     {:req-opts {:compress true}}
-                     (fn [err content]
-                       (is (= err nil))
-                       (is (> (count content) 0))
-                       (is (= (parse-ipfs-content content) {:this-is "EDN FILE"}))
-                       (done)))))
+         (files/add (to-buffer "{:this-is \"EDN FILE\"}")
+                    (fn [err files]
+                      (let [hash (:Hash files)]
+                        (files/fget hash
+                                    {:req-opts {:compress true}}
+                                    (fn [err content]
+                                      (is (= err nil))
+                                      (is (> (count content) 0))
+                                      (is (= (parse-ipfs-content content) {:this-is "EDN FILE"}))
+                                      (done))))))))
 
 (deftest cat-test []
   (async done
          (core/init-ipfs)
-         (files/fcat "QmU5RLaShDjmXD2qb123Soj3nHKgQn76d8jab8mNp55X1V"
-                     {:req-opts {:compress true}}
-                     (fn [err content]
-                       (is (= err nil))
-                       (is (= (cljs.reader/read-string content) {:this-is "EDN FILE"}))
-                       (done)))))
+         (files/add (to-buffer "{:this-is \"EDN FILE\"}")
+                    (fn [err files]
+                      (let [hash (:Hash files)]
+                        (files/fcat hash
+                                    {:req-opts {:compress true}}
+                                    (fn [err content]
+                                      (is (= err nil))
+                                      (is (= (cljs.reader/read-string content) {:this-is "EDN FILE"}))
+                                      (done))))))))


### PR DESCRIPTION
### NDJSON support

The format IPFS API uses for responses is not pure JSON, but NDJSON (Newline Delimiter JSON). For example, the response of an _add_ call, when using the _wrap-with-directory_, it is not a JSON array containing the 2 added refs, but 2 independent JSON objects separated by a line delimiter.

Thus, this response is not automatically parsed to a JSON structure by axios, as it is not a valid JSON format. This PR adds support for NDJSON, such that it parses the response to an array of JSON objects when the response comes in this format.

### Blob support
Blob support was removed in favor of using Buffer. This PR adds again Blob support, in order to 1) simplify its usage when integrated with some file upload mechanism and to 2) preserve file name and other properties which are not kept when converting the blob to a buffer

### Test fixes
The get and cat tests were depending on an edn file which is no longer available. To fix this, the file is added before the tests to make sure it is there before continuing